### PR TITLE
Fixed Navigation Links

### DIFF
--- a/ED/KAI/releases.html
+++ b/ED/KAI/releases.html
@@ -7,7 +7,7 @@
 <body>
 Low-Rez Labs Internal File Server                               <br>
 <a href="../../Login.html?returnto=KAI">Current Authorization: Guest (Log in)                           </a><br>
-Current Directory: <a href="../../root.html">~/</a><a href="../index.html">ED/</a><a href="releases.html">KAI</a>                                     <br>
+Current Directory: <a href="../../index.html">~/</a><a href="../index.html">ED/</a><a href="releases.html">KAI</a>                                     <br>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~<br>
 <a href="KAI.Alpha.0.3.zip">KAI.Alpha.0.3.zip                                | Zipped Folder</a><br>
 <a href="EDAI.Alpha.0.2.zip">EDAI.Alpha.0.2.zip                               | Zipped Folder</a><br>

--- a/ED/index.html
+++ b/ED/index.html
@@ -7,7 +7,7 @@
 <body>
 Low-Rez Labs Internal File Server                               <br>
 <a href="../Login.html?returnto=ED">Current Authorization: Guest (Log in)                           </a><br>
-Current Directory: <a href="../root.html">~/</a><a href="index.html">ED</a>                                      <br>
+Current Directory: <a href="../index.html">~/</a><a href="index.html">ED</a>                                      <br>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~<br>
 <a href="KAI/releases.html">KAI VoiceAttack Profile - Releases               | Folder       </a><br>
 <a href="PFLicense.zip">Pilot's Federation License                       | Zipped Folder</a><br>

--- a/announcements/list.html
+++ b/announcements/list.html
@@ -7,7 +7,7 @@
 <body>
 Low-Rez Labs Internal File Server                               <br>
 <a href="../Login.html?returnto=announcements">Current Authorization: Guest (Log in)                           </a><br>
-Current Directory: <a href="../root.html">~/</a><a href="list.html">Announcements</a>                              <br>
+Current Directory: <a href="../index.html">~/</a><a href="list.html">Announcements</a>                              <br>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~<br>
 <a href="Public Interface Under Construction.txt" download>Public Interface Under Construction.txt          | Text File    </a><br>
                                                  |              <br>

--- a/archive/index.html
+++ b/archive/index.html
@@ -7,7 +7,7 @@
 <body>
 Low-Rez Labs Internal File Server                               <br>
 <a href="../Login.html?returnto=archive">Current Authorization: Guest (Log in)                           </a><br>
-Current Directory: <a href="../root.html">~/</a><a href="index.html">Archive</a>                                    <br>
+Current Directory: <a href="../index.html">~/</a><a href="index.html">Archive</a>                                    <br>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~<br>
 <a href="(1) Unread Message.txt" download>(1) Unread Message.txt                           | Text File    </a><br>
 <a href="Tower Unite - Living the Dream.txt" download>Tower Unite - Living the Dream.txt               | Text File    <br>

--- a/furry/main.html
+++ b/furry/main.html
@@ -7,7 +7,7 @@
 <body>
 Low-Rez Labs Internal File Server                               <br>
 <a href="../Login.html?returnto=furry">Current Authorization: Guest (Log in)                           </a><br>
-Current Directory: <a href="../root.html">~/</a><a href="Main.html">Furry</a>                                      <br>
+Current Directory: <a href="../index.html">~/</a><a href="Main.html">Furry</a>                                      <br>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~<br>
 It doesn't look like there's anything here yet.  |              <br>
                                                  |              <br>

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 <body>
 Low-Rez Labs Internal File Server                               <br>
 <a href="Login.html?returnto=root">Current Authorization: Guest (Log in)                           </a><br>
-Current Directory: <a href="root.html">~</a>                                            <br>
+Current Directory: <a href="index.html">~</a>                                            <br>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~<br>
 <a href="announcements/Public Interface Under Construction.txt" download>Latest Announcement: Public Interface Under Construction        </a><br>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~<br>


### PR DESCRIPTION
Turns out when I restructured the site to remove the splash page I
forgot to change all the links to point to index.html instead of
root.html, since I had to change the name of the root directory page.
Oops.